### PR TITLE
Sirjojo69 Fix: Accept fingerprint-pinned certificate even when expired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## **WORK IN PROGRESS**
 
+- Fix: The factory-baked self-signed certificate used by all KLF-200 devices expired on 2026-07-12, causing every connection to fail with `certificate has expired` regardless of the device's actual trustworthiness. The connection is now accepted when the peer certificate's fingerprint matches the expected (pinned) fingerprint, even if the certificate's validity period has lapsed.
 - [#187](https://github.com/MiSchroe/klf-200-api/issues/187) Fix potential memory leaks.
 - [#195](https://github.com/MiSchroe/klf-200-api/issues/195) Remove unnecessary files from distribution.
 - **BREAKING CHANGE:** Changed internal Disposable interface to use [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management).

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1,4 +1,4 @@
-﻿"use strict";
+"use strict";
 
 import debugModule from "debug";
 import "disposablestack/auto";
@@ -816,15 +816,28 @@ export class Connection implements IConnection, AsyncDisposable {
 							this.connectionOptions
 								? this.connectionOptions
 								: {
-										rejectUnauthorized: true,
+										// Node's built-in verification also rejects certificates that are
+										// only "invalid" because they are expired or not yet valid. The
+										// KLF-200 uses a fixed, factory-baked self-signed certificate whose
+										// validity period is unrelated to trustworthiness, so we disable the
+										// built-in check here and perform our own fingerprint-based
+										// verification in the secureConnect handler below.
+										rejectUnauthorized: false,
 										ca: [this.CA],
 										checkServerIdentity: (host, cert) => this.checkServerIdentity(host, cert),
 									},
 							() => {
 								debug("Secure connection established.");
 								// Callback on event "secureConnect":
-								// Resolve promise if connection is authorized, otherwise reject it.
-								if (this.sckt?.authorized) {
+								// Resolve promise if the connection is authorized. Since we set
+								// rejectUnauthorized to false above, `authorized` will be false for
+								// *any* verification failure, including a merely expired certificate.
+								// We therefore fall back to our own pinned-fingerprint check: if the
+								// peer's certificate fingerprint matches the expected one, we still
+								// trust the connection regardless of the reason `authorized` is false.
+								const isTrustedByFingerprint =
+									this.checkServerIdentity(this.host, this.sckt!.getPeerCertificate()) === undefined;
+								if (this.sckt?.authorized || isTrustedByFingerprint) {
 									// Remove login error handler
 									this.sckt?.off("error", loginErrorHandler);
 									stack.defer(async () => {


### PR DESCRIPTION
The factory-baked self-signed certificate used by all KLF-200 devices
expired on 2026-07-12T09:38:26Z. Since that date, every connection
attempt fails with "certificate has expired", even though the peer's
certificate fingerprint still matches the expected (pinned) fingerprint
exactly.

This PR sets rejectUnauthorized to false and performs the trust
decision manually in the secureConnect handler: the connection is
still rejected on any genuine identity mismatch (wrong fingerprint),
but is no longer rejected purely because the certificate's validity
period has lapsed, as long as the pinned fingerprint matches.

Verified locally: TypeScript compiles cleanly (tsc -b), ESLint passes,
and the patch resolves a real-world "certificate has expired" failure
against a physical KLF-200 device.